### PR TITLE
Update draft configuration for toltec package

### DIFF
--- a/package
+++ b/package
@@ -42,6 +42,7 @@ package() {
     sed -i 's|/home/root/ReTerm/ReTerm|/opt/usr/lib/reterm/ReTerm|' "$pkgdir"/opt/bin/ReTerm
     install -D -m 644 -t "$pkgdir"/opt/etc/draft "$srcdir"/draft/reterm.draft
     sed -i 's|/home/root/ReTerm/ReTerm.sh|/opt/bin/ReTerm|' "$pkgdir"/opt/etc/draft/reterm.draft
+    sed -i 's|killall -9 dotnet|killall ReTerm|' "$pkgdir"/opt/etc/draft/reterm.draft
     install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons "$srcdir"/draft/reterm.png
     install -D -m 644 -t "$pkgdir"/opt/usr/share/applications "$srcdir"/oxide/ReTerm.oxide
 }


### PR DESCRIPTION
Since it's compiled as a standalone binary, killall -9 dotnet isn't doing the correct thing.